### PR TITLE
Handle empty VMF keys and also allow '@' symbol in VMF keys

### DIFF
--- a/src/main/java/com/lathrum/VMF2OBJ/dataStructure/map/VMF.java
+++ b/src/main/java/com/lathrum/VMF2OBJ/dataStructure/map/VMF.java
@@ -40,13 +40,13 @@ public class VMF {
 
 	public static VMF parseVMF(String text) {
 		String objectRegex = "([a-zA-z._0-9]+)([{\\[])";
-		String keyValueRegex = "(\"[a-zA-z._0-9@]+\"|\"\")(\"[^\"]*\")";
+		String keyValueRegex = "(\"[a-zA-z._0-9]+\"|\"\")(\"[^\"]*\")";
 		String objectCommaRegex = "[}\\]]\"";
 		String cleanUpRegex = ",([}\\]])";
 
 		text = text.replaceAll("\\\\", "/"); // Replace backslashs with forwardslashs
 		text = text.replaceAll("(?m)^\\s*//(.*)", ""); // Remove all commented lines
-		text = text.replaceAll("\\x1B|#", ""); // Remove all illegal characters
+		text = text.replaceAll("\\x1B|#|@", ""); // Remove all illegal characters
 		text = text.replaceAll("(\".+)[{}](.+\")", "$1$2"); // Remove brackets in quotes
 		text = text.replaceAll("\"Code\"(.*)", ""); // Remove gmod Lua code
 		text = text.replaceAll("(\"achievement.+)\\[[0-9]\\]\"", "$1\""); // Remove achievement arrays

--- a/src/main/java/com/lathrum/VMF2OBJ/dataStructure/map/VMF.java
+++ b/src/main/java/com/lathrum/VMF2OBJ/dataStructure/map/VMF.java
@@ -40,7 +40,7 @@ public class VMF {
 
 	public static VMF parseVMF(String text) {
 		String objectRegex = "([a-zA-z._0-9]+)([{\\[])";
-		String keyValueRegex = "(\"[a-zA-z._0-9]+\")(\"[^\"]*\")";
+		String keyValueRegex = "(\"[a-zA-z._0-9@]+\"|\"\")(\"[^\"]*\")";
 		String objectCommaRegex = "[}\\]]\"";
 		String cleanUpRegex = ",([}\\]])";
 


### PR DESCRIPTION
Handling some weirdness for some HL2 maps when decompiled with VMEX. Some VMF files contain empty keys (for example d1_town_01) and some others contain '@' symbol in the VMF keys (for example d1_town_02). This resulted in an invalid JSON when parsed and the application crashed.